### PR TITLE
Implement basic rate-limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,18 @@ $ go run deleter.go
 ## Cookies
 
 Cookies are saved to `$HOME/.go-cookies` if the `$GOCOOKIES` variable is not set (see https://github.com/juju/persistent-cookiejar).
+
+## Options
+
+### Rate-limiting
+
+Facebook will temp-block you if you make too many requests too quickly. Run the command with the `-rateLimit <time in ms>` to introduce a delay before each request. If you're getting hung up on just searches or deletes, you can disable rate-limiting for one or the other with `-limitSearch=0` or `-limitDelete=0`.
+
+E.g. one of:
+
+```
+$ ./deleter-linux -rateLimit 500
+$ ./deleter-linux -rateLimit 500 -limitSearch=0
+$ ./deleter-linux -rateLimit 500 -limitDelete=0
+```
+


### PR DESCRIPTION
fix #16 

Very basic rate-limiting command-line options. No logic, just a simple sleep before each request, but should be sufficient for our purposes. Off by default.