### PR TITLE
increase default rate limit to prevent quick lockouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This program can be used to clean up a Facebook account without deleting the entire account.
 
-_Warning: Facebook has some measures in place to prevent high-frequency activity such as the one this tool provides. The current rate limit value has currently been set to 100 ms to avoid detection, but the delay might not be enough and this could still result in your activity log getting temporarily blocked. Please check out the [Rate-limiting](#rate-limiting) section if you want to increase/decrease this delay._
+_Warning: Facebook has some measures in place to prevent high-frequency activity such as the one this tool provides. The current rate limit value has currently been set to 1000 ms to avoid detection, but the delay might not be enough and this could still result in your activity log getting temporarily blocked. Please check out the [Rate-limiting](#rate-limiting) section if you want to increase/decrease this delay._
 
 _Note: Facebook has a very strange login process. Please open a GitHub issue if the program is not able to login. Here's a [workaround for the login process](https://github.com/marcelja/facebook-delete/wiki/Login-with-browser-cookie) which you can also use if your account has two-factor authentication enabled._
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This program can be used to clean up a Facebook account without deleting the entire account.
 
-_Warning: Facebook has some measures in place to prevent high-frequency activity such as the one this tool provides. The current rate limit value has currently been set to 1000 ms to avoid detection, but the delay might not be enough and this could still result in your activity log getting temporarily blocked. Please check out the [Rate-limiting](#rate-limiting) section if you want to increase/decrease this delay._
+_Warning: Facebook has some measures in place to prevent high-frequency activity such as the one this tool provides. The current rate limit value has currently been set to 5000 ms to avoid detection, but the delay might not be enough and this could still result in your activity log getting temporarily blocked. Please check out the [Rate-limiting](#rate-limiting) section if you want to increase/decrease this delay._
 
 _Note: Facebook has a very strange login process. Please open a GitHub issue if the program is not able to login. Here's a [workaround for the login process](https://github.com/marcelja/facebook-delete/wiki/Login-with-browser-cookie) which you can also use if your account has two-factor authentication enabled._
 

--- a/deleter.go
+++ b/deleter.go
@@ -526,7 +526,7 @@ func validateMonthsFlag(flagContent string) bool {
 }
 
 func main() {
-	flag.IntVar(&rateLimit, "rateLimit", 1000, "Wait this many milliseconds between requests.")
+	flag.IntVar(&rateLimit, "rateLimit", 5000, "Wait this many milliseconds between requests.")
 	flag.BoolVar(&limitSearch, "limitSearch", true, "Rate-limit searching for things to delete.")
 	flag.BoolVar(&limitDelete, "limitDelete", true, "Rate-limit deleting things.")
 	flag.StringVar(&customYears, "customYears", "", "Comma-separated years (YYYY) to select.")

--- a/deleter.go
+++ b/deleter.go
@@ -526,7 +526,7 @@ func validateMonthsFlag(flagContent string) bool {
 }
 
 func main() {
-	flag.IntVar(&rateLimit, "rateLimit", 100, "Wait this many milliseconds between requests.")
+	flag.IntVar(&rateLimit, "rateLimit", 1000, "Wait this many milliseconds between requests.")
 	flag.BoolVar(&limitSearch, "limitSearch", true, "Rate-limit searching for things to delete.")
 	flag.BoolVar(&limitDelete, "limitDelete", true, "Rate-limit deleting things.")
 	flag.StringVar(&customYears, "customYears", "", "Comma-separated years (YYYY) to select.")


### PR DESCRIPTION
The default rate limit is too fast, and results in a lockout very quickly. I think that it would be better to set the default timeout to be longer, so that users don't get locked out right away. Users can then ratchet down the timeout on their own if they want to.

I changed it to 1000ms, which is just a guess. It would take quite a long time to figure out the optimal wait time, because the only way to test it is by getting locked out, and then waiting until you're unlocked to try something else. 